### PR TITLE
Add isolated temp fixtures module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ Clean, maintainable test configuration using organized fixture modules
 
 # Import all fixtures from organized modules
 from .fixtures.sdk_fixtures import *
-from .fixtures.temp_fixtures import * 
+from .fixtures.temp_fixtures import *
 from .fixtures.sample_fixtures import *
 
 # Import pytest hooks for parallel execution

--- a/tests/fixtures/temp_fixtures.py
+++ b/tests/fixtures/temp_fixtures.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+Temporary directory fixtures for tests.
+Provides worker-isolated directories that are cleaned up after use.
+"""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_temp_dir():
+    """Create an isolated temporary directory for a test.
+
+    Uses the worker-specific base directory configured by the pytest
+    hooks (``PYTEST_TMP_DIR``) when available so parallel test runs do
+    not interfere with each other. The directory is removed after the
+    test finishes.
+    """
+    base_dir = Path(os.environ.get("PYTEST_TMP_DIR", tempfile.gettempdir()))
+    temp_dir = Path(tempfile.mkdtemp(prefix="tts_test_", dir=base_dir))
+    try:
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- restore `tests/fixtures/temp_fixtures.py` with an `isolated_temp_dir` fixture to stop ModuleNotFoundError during test setup
- ensure `tests/conftest.py` ends cleanly after importing hooks

## Testing
- `PYTHONPATH=src python -m pytest tests/test_voice_mock_integration.py::TestVoiceIntegrationWithMocks::test_voice_integration_with_mocks -q`
- ⚠️ `PYTHONPATH=src python -m pytest tests/test_voice_mock_integration.py -q` *(missing ffprobe causes a test failure)*

------
https://chatgpt.com/codex/tasks/task_e_68a6362765c48326abeb8f2a82decc45