### PR TITLE
docs: explain prosody interface

### DIFF
--- a/docs/prosody.md
+++ b/docs/prosody.md
@@ -1,0 +1,21 @@
+# Prosody Interface
+
+The project provides a simple prosody system that lets the CLI adjust rate, pitch and volume using named styles and intensity levels.
+
+## CLI usage
+- `--prosody-style <style>` – select a speaking style such as `newscast` or `dramatic`.
+- `--prosody-intensity <1-5>` – control how strongly the style affects rate, pitch and volume.
+- `--prosody-list` and `--prosody-info <style>` – discover available styles and inspect their details.
+
+## Configuration files
+- `src/prosody/config/styles.yaml` defines each style with baseline `rate`, `pitch`, `volume`, and `emphasis_strength`, plus intensity multipliers 1–5 that scale the effect.
+- `src/prosody/config/calibration.yaml` optionally adjusts these parameters per voice so styles sound natural on different voices.
+
+## Parameter conversion
+- `get_prosody_params(style, intensity)` in `src/prosody/prosody.py` applies the chosen style and intensity to produce standard prosody parameters like `{ "rate": "+5%", "pitch": "+8Hz", "volume": "+4dB" }`.
+- The resulting values are stored in `ConversionParams` (`src/engines/core/types.py`) through the `style` and `style_intensity` fields so engines can apply them consistently.
+
+## Example
+```bash
+python src/cli.py script.txt --engine edge_tts --prosody-style newscast --prosody-intensity 3
+```


### PR DESCRIPTION
## Summary
- document prosody CLI flags and configuration files
- outline how styles and intensity convert to standard rate/pitch/volume parameters

## Testing
- `python -m pytest tests/ -v` *(fails: `NameError: name 'os' is not defined` in prosody CLI tests and missing `ffprobe` for mock engine validation)*

------
https://chatgpt.com/codex/tasks/task_e_68a634cf3c7c8326b2d678d8189228b6