### PR TITLE
Fix test imports and document test setup

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -10,6 +10,14 @@ The test suite is designed with two main approaches:
 
 ## Quick Start
 
+Before running any tests, install the development dependencies:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+The test suite automatically adds the `src` directory to `PYTHONPATH`, so no additional package installation is required.
+
 **Development Testing (Recommended)**
 ```bash
 # Fast mock tests - use during development

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@
 -r requirements-tts.txt
 pytest>=7.0
 pytest-xdist>=3.0.0
+pytest-asyncio>=0.23
 

--- a/tests/fixtures/sdk_fixtures.py
+++ b/tests/fixtures/sdk_fixtures.py
@@ -8,6 +8,12 @@ import pytest
 import sys
 from pathlib import Path
 
+# Ensure the source package is importable without installation
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
 from tts.sdk import TTSSDK
 from tests.mocks import MockTTSSDK, MockEngineFactory
 from tests.test_helpers import should_use_mock_engines, get_test_mode

--- a/tests/test_prosody_cli_basic_e2e.py
+++ b/tests/test_prosody_cli_basic_e2e.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import shutil
+import os
 from pathlib import Path
 import pytest
 


### PR DESCRIPTION
## Summary
- Ensure test fixtures add the `src` directory to `PYTHONPATH` so `tts` can be imported without package installation
- Document installing dev dependencies and automatic path configuration in testing guide
- Include `pytest-asyncio` for async tests and add missing `os` import in prosody CLI tests

## Testing
- `python -m pytest tests/ -q` *(fails: CLI engine initialization errors and missing ffprobe)*

------
https://chatgpt.com/codex/tasks/task_e_68a63b4bc62483269554ab840ee8d786