### PR TITLE
Ensure prosody CLI test runs in offline environments

### DIFF
--- a/tests/test_prosody_cli_basic_e2e.py
+++ b/tests/test_prosody_cli_basic_e2e.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import shutil
 from pathlib import Path
+import os
 import pytest
 
 from tests.test_helpers import should_use_mock_engines, get_test_mode, validate_audio_and_print_info
@@ -236,7 +237,7 @@ async def test_prosody_cli_without_flags():
             sys.executable,
             "-m", "cli",
             str(sample_file),
-            "--engine", "edge_tts",
+            "--engine", "pyttsx3",
             "-o", str(output_file)
         ]
         


### PR DESCRIPTION
## Summary
- import missing `os` in prosody CLI tests
- run non-prosody CLI test with offline `pyttsx3` engine

## Testing
- `PYTHONPATH=src pytest tests/test_prosody_cli_basic_e2e.py::test_prosody_cli_without_flags -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6387db5e88326884648ddb884bd8b