### PR TITLE
Ensure pytest-asyncio plugin is loaded

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,10 @@ Simplified pytest configuration with modular fixture organization
 Clean, maintainable test configuration using organized fixture modules
 """
 
+# Explicitly register pytest-asyncio so async tests have an event loop
+# available even when pytest's auto-discovery misses the plugin.
+pytest_plugins = ("pytest_asyncio",)
+
 # Import all fixtures from organized modules
 from .fixtures.sdk_fixtures import *
 from .fixtures.temp_fixtures import *


### PR DESCRIPTION
## Summary
- Explicitly register `pytest-asyncio` plugin in `tests/conftest.py` to guarantee async support.

## Testing
- `python -m pytest tests/ -v` *(fails: Mock edge_tts conversion should succeed; Audio validation failed: ffprobe missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9eab495a083269f53cdb1ae526aba