### PR TITLE
Add MLK prosody demo with CLI pipeline and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,24 @@ USE_REAL_ENGINES=true python -m pytest tests/ -v
 - **Prototyping**: Quick audio mockups for multilingual applications
 - **Global Content**: Easily create audio versions for international audiences
 
+## How to try
+
+Get started with the inspirational "I Have a Dream" demo which showcases preset loading, annotation parsing, performance craft, and audio rendering.
+
+```bash
+# Setup (from repository root)
+pip install -r requirements-core.txt -r requirements-tts.txt
+
+# Dry run to see the render plan
+./prosody demo-mlk --out demo.wav --dry-run
+
+# Render silent audio
+./prosody demo-mlk --out demo.wav
+
+# Run the end-to-end test
+python -m pytest tests/test_demo_mlk_cli.py -v
+```
+
 ## 📈 Performance
 
 - **Speed**: Typically 2-5x faster than real-time playback

--- a/prosody
+++ b/prosody
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Convenience script for prosody demos
+# Usage: ./prosody demo-mlk --out out.wav
+
+export PYTHONPATH="$(dirname "$0")/src:$PYTHONPATH"
+python -m prosody.cli "$@"

--- a/src/prosody/cli.py
+++ b/src/prosody/cli.py
@@ -1,0 +1,30 @@
+"""CLI entry point for prosody demos."""
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+from .demo_mlk import run_demo
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(prog="prosody", description="Prosody demonstration commands")
+    subparsers = parser.add_subparsers(dest="command")
+
+    demo = subparsers.add_parser("demo-mlk", help="Render the 'I Have a Dream' excerpt")
+    demo.add_argument("--out", required=True, help="Path to output WAV file")
+    demo.add_argument("--voice", help="Override voice name")
+    demo.add_argument("--dry-run", action="store_true", help="Print render plan without audio")
+    demo.add_argument("--seed", type=int, help="Random seed for reproducible variations")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "demo-mlk":
+        out_path = Path(args.out)
+        run_demo(out_path, args.voice, args.dry_run, args.seed)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prosody/demo_mlk.py
+++ b/src/prosody/demo_mlk.py
@@ -1,0 +1,112 @@
+"""Demonstration pipeline for the "I Have a Dream" excerpt.
+
+Stages:
+    1. Preset loading
+    2. Annotation parsing
+    3. Performance crafting
+    4. Audio rendering (silent for demo/testing)
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Optional
+
+from pydub import AudioSegment
+import yaml
+
+@dataclass
+class Segment:
+    """A piece of the script after annotation parsing."""
+    kind: str  # 'text' or 'pause'
+    content: str = ""
+    duration: float = 0.0  # seconds for pauses or precomputed speech
+    pitch: float = 0.0
+    volume: float = 0.0
+
+
+def load_preset(name: str) -> Dict:
+    """Load a preset YAML configuration."""
+    preset_path = Path(__file__).parent / "presets" / f"{name}.yaml"
+    with preset_path.open() as f:
+        return yaml.safe_load(f)
+
+
+def parse_script(path: Path) -> List[Segment]:
+    """Parse the annotated script into text and pause segments."""
+    text = path.read_text().strip()
+    parts = re.split(r"\[pause=([0-9.]+)\]", text)
+    segments: List[Segment] = []
+    for i, part in enumerate(parts):
+        if i % 2 == 0:
+            if part.strip():
+                segments.append(Segment(kind="text", content=part.strip()))
+        else:
+            segments.append(Segment(kind="pause", duration=float(part)))
+    return segments
+
+
+def craft_performance(preset: Dict, segments: List[Segment], voice: Optional[str]) -> List[Segment]:
+    """Apply preset parameters and repetition strategy to segments."""
+    base_pitch = preset.get("pitch", 0)
+    base_volume = preset.get("volume", 0)
+    repetition = preset.get("repetition", {})
+    phrase = repetition.get("phrase")
+    pitch_inc = repetition.get("pitch_increment", 0)
+    volume_inc = repetition.get("volume_increment", 0)
+    counts: Dict[str, int] = {}
+
+    tempo = preset.get("tempo", 100)  # words per minute
+    for seg in segments:
+        if seg.kind == "text":
+            text = seg.content
+            if phrase and phrase.lower() in text.lower():
+                counts[phrase] = counts.get(phrase, 0) + 1
+                seg.pitch = base_pitch + pitch_inc * counts[phrase]
+                seg.volume = base_volume + volume_inc * counts[phrase]
+            else:
+                seg.pitch = base_pitch
+                seg.volume = base_volume
+            words = len(text.split())
+            seg.duration = words / float(tempo) * 60.0
+    return segments
+
+
+def render_audio(plan: List[Segment], out_path: Path, seed: Optional[int]) -> float:
+    """Render the performance plan to a WAV file (silent audio)."""
+    if seed is not None:
+        random.seed(seed)
+    audio = AudioSegment.silent(duration=0)
+    for seg in plan:
+        if seg.kind == "pause":
+            duration_ms = int(seg.duration * 1000)
+            audio += AudioSegment.silent(duration=duration_ms)
+        else:
+            # For text, create silent audio based on computed duration
+            duration_ms = int(seg.duration * 1000)
+            audio += AudioSegment.silent(duration=duration_ms)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    audio.export(out_path, format="wav")
+    return audio.duration_seconds
+
+
+def run_demo(out: Path, voice: Optional[str], dry_run: bool, seed: Optional[int]) -> float:
+    preset = load_preset("prophetic_oratory")
+    script_path = Path(__file__).parent / "scripts" / "i_have_a_dream.txt"
+    segments = parse_script(script_path)
+    plan = craft_performance(preset, segments, voice)
+    if dry_run:
+        for seg in plan:
+            if seg.kind == "text":
+                print(f"TEXT: '{seg.content}' | dur={seg.duration:.2f}s pitch={seg.pitch}Hz vol={seg.volume}dB")
+            else:
+                print(f"PAUSE: {seg.duration:.2f}s")
+        print(f"Preset: prophetic_oratory, Voice: {voice or preset.get('voice')}")
+        print("Dry run - no audio generated")
+        return 0.0
+    duration = render_audio(plan, out, seed)
+    print(f"Preset: prophetic_oratory, Voice: {voice or preset.get('voice')}, Output: {out}, Duration: {duration:.2f}s")
+    return duration

--- a/src/prosody/presets/prophetic_oratory.yaml
+++ b/src/prosody/presets/prophetic_oratory.yaml
@@ -1,0 +1,12 @@
+# Preset for prophetic oratory style
+# Defines base prosody parameters and a repetition strategy
+
+tempo: 400          # words per minute
+pitch: 0            # base pitch offset in Hz
+volume: 0           # base volume offset in dB
+style: dramatic
+voice: en-US-JennyNeural
+repetition:
+  phrase: "I have a dream"
+  pitch_increment: 2    # Hz increase per repetition
+  volume_increment: 1   # dB increase per repetition

--- a/src/prosody/scripts/i_have_a_dream.txt
+++ b/src/prosody/scripts/i_have_a_dream.txt
@@ -1,0 +1,3 @@
+I have a dream that one day this nation will rise up and live out the true meaning of its creed [pause=0.5]
+I have a dream that one day on the red hills of Georgia the sons of former slaves and the sons of former slave owners will be able to sit down together at the table of brotherhood [pause=0.5]
+I have a dream today [pause=0.5]

--- a/tests/test_demo_mlk_cli.py
+++ b/tests/test_demo_mlk_cli.py
@@ -1,0 +1,21 @@
+import subprocess
+import wave
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.e2e
+def test_demo_mlk_cli(tmp_path):
+    out_path = tmp_path / "dream.wav"
+    cmd = [str(Path(__file__).resolve().parent.parent / "prosody"), "demo-mlk", "--out", str(out_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert out_path.exists()
+
+    with wave.open(str(out_path), "rb") as wf:
+        frames = wf.getnframes()
+        rate = wf.getframerate()
+        duration = frames / float(rate)
+
+    assert 5 <= duration <= 15


### PR DESCRIPTION
## Summary
- add prophetic_oratory preset and annotated MLK excerpt
- introduce `prosody demo-mlk` CLI showing preset → annotation → performance → render
- include end-to-end test and README instructions

## Testing
- `python -m pytest tests/ -v`
- `python -m pytest tests/test_demo_mlk_cli.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68aa22f72ea883269b980408100b4f74